### PR TITLE
fix: do not fetch tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,6 @@ name: "Publish container image"
 
 on:
   push:
-    branches:
-      - main
     tags: 
       - v*
 
@@ -21,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Unshallow
-        run: git fetch --prune --tags --unshallow
+        run: git fetch --prune --unshallow
 
       - name: Describe the current state
         run: git describe --tags --always


### PR DESCRIPTION
When the trigger is a tag event, the tag is already there, so passing --tags to git fetch causes it to fail.

Remove the commit to main event because we do not need to publish images for every single change that makes it to main, only for the ones that get published.