### PR TITLE
Add get-latest-gbt-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ FROM go as tools
     RUN env GOBIN=/build go install github.com/grafana/grizzly/cmd/grr@5f301fd6c773
     # RUN env GOBIN=/build go install github.com/grafana/grizzly/cmd/grr@v0.2.1
 
+    # Add semversort
+    RUN env GOBIN=/build go install github.com/whereswaldon/semversort@v0.0.6
+
     # Add golangci-lint
     COPY --from=registry.hub.docker.com/golangci/golangci-lint:v1.55.2 /usr/bin/golangci-lint /build
 
@@ -54,6 +57,9 @@ FROM go as tools
 
     # Add gotestsum
     RUN env GOBIN=/build go install gotest.tools/gotestsum@v1.11.0
+
+    # Add jq
+    COPY --from=ghcr.io/jqlang/jq:1.7 /jq /build
 
 FROM go AS k6
     # The grafana/xk6 image only exists for amd64, so we need to build it for
@@ -114,3 +120,5 @@ FROM registry.hub.docker.com/library/debian:stable-slim AS final
     COPY --from=skopeo /build/* /usr/local/bin/
 
     COPY lib/image-test /usr/local/bin
+
+    COPY lib/get-latest-gbt-version /usr/local/bin

--- a/lib/get-latest-gbt-version
+++ b/lib/get-latest-gbt-version
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+skopeo list-tags docker://ghcr.io/grafana/grafana-build-tools |
+	jq -r '.Tags[] | select(. | startswith("v"))' |
+	semversort |
+	tail -1

--- a/lib/image-test
+++ b/lib/image-test
@@ -48,6 +48,9 @@ mage -version
 echo '=== nilaway'
 nilaway -help
 
+echo '=== semversort'
+semversort < /dev/null
+
 echo '=== grr'
 grr --version
 
@@ -62,6 +65,9 @@ git-chglog --help
 
 echo '=== gotestsum'
 gotestsum --version
+
+echo '=== jq'
+jq --version
 
 echo '=== gcc'
 gcc --version
@@ -79,3 +85,6 @@ pkg-config --version
 
 echo '=== skopeo'
 skopeo --version
+
+echo '=== get-latest-gbt-version'
+command -v get-latest-gbt-version


### PR DESCRIPTION
This small script can be used to find the most recent release of grafana-build-tools. Client repositories can use this to figure out if their version is up-to-date.