### PR TITLE
Update tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.21.6 as go
+FROM registry.hub.docker.com/library/golang:1.21.7 as go
 
     COPY lib/go.env /usr/local/go
 
@@ -59,13 +59,13 @@ FROM go as tools
 FROM go AS k6
     # The grafana/xk6 image only exists for amd64, so we need to build it for
     # the target architecture.
-    RUN env GOBIN=/build go install go.k6.io/xk6/cmd/xk6@v0.9.2
+    RUN env GOBIN=/build go install go.k6.io/xk6/cmd/xk6@v0.10.0
 
     # The grafana/k6 image only exists for amd64, so we need to build it for
     # the architecture we are targeting. The simplest way to build k6 is to
     # (ab)use xk6 to build a binary without any extensions. In the future, if
     # we wanted additional extensions, this is the place to add them.
-    RUN /build/xk6 build v0.46.0 --output /build/k6
+    RUN /build/xk6 build v0.49.0 --output /build/k6
 
 FROM registry.hub.docker.com/library/debian:stable-slim as skopeo
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,7 +16,7 @@ git-chglog:
   type: go
 go:
   repo: registry.hub.docker.com/library/golang
-  version: 1.21.6
+  version: 1.21.7
   type: docker
 golangci-lint:
   repo: github.com/golangci/golangci-lint
@@ -48,7 +48,7 @@ jsonnet:
   type: go
 k6:
   repo: github.com/grafana/k6
-  version: v0.46.0
+  version: v0.49.0
   type: go
 mage:
   repo: github.com/magefile/mage
@@ -73,7 +73,7 @@ shellcheck:
   type: docker
 skopeo:
   repo: github.com/containers/skopeo
-  version: v1.14.0
+  version: v1.14.2
   type: go
 wire:
   repo: github.com/google/wire
@@ -81,5 +81,5 @@ wire:
   type: go
 xk6:
   repo: go.k6.io/xk6
-  version: v0.9.2
+  version: v0.10.0
   type: go


### PR DESCRIPTION
- Go 1.21.7
- k6 v0.49.0
- skopeo v1.14.2
- xk6 v0.10.0

This fixes a number of compilation issues with Go 1.22.0. Create this image just in case someone cannot upgrade to that version just yet.