### PR TITLE
Limit build paralellism

### DIFF
--- a/.github/workflows/buildkitd.toml
+++ b/.github/workflows/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          config: .github/workflows/buildkitd.toml
 
       - name: Cache Docker layers
         uses: actions/cache@v4


### PR DESCRIPTION
For whatever reason, the build is failing after introducing more stages. I suspect it's because there are more stages than whatever buildkit is using for paralellism, and it's hitting some limit elsewhere.