### PR TITLE
Fix: release script should use `make image-local`

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -111,7 +111,7 @@ else
 	cur_version=$(git describe --tags | cut -d- -f1)
 
 	if ! docker image inspect "${gbt_image}" > /dev/null 2>&1 ; then
-		make build-local
+		make image-local
 	fi
 
 	docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" --workdir /work "${gbt_image}" \


### PR DESCRIPTION
`make build-local` doesn't build create a container image, it simply builds the binaries. `make image-local` takes those binaries and creates an image with them.

The release script needs git-chglog to create the CHANGELOG.md file, and instead of assuming it's available locally, it uses the one that is part of the container image. It's a bit heavy-handed, but it gets the job done.