### PR TITLE
Disable pinning of docker dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    ":semanticCommitsDisabled"
+    ":semanticCommitsDisabled",
+    "default:pinDigestsDisabled"
   ],
 
   "branchPrefix": "grafanarenovatebot/",

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,7 +34,6 @@ jobs:
           app-id: ${{ env.GRAFANA_RENOVATE_APP_ID }}
           private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          revoke: true
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@dd4d265eb8646cd04fc5f86ff8bc8d496d75a251 # v40.2.8
         with:


### PR DESCRIPTION
Renovate broke something and the absence of docker digest is causing it to fail with some unrelated "cannot create branch error".

Just disable it.