### PR TITLE
Release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 ## [Unreleased]
 
 
+<a name="v0.28.0"></a>
+## [v0.28.0] - 2024-10-29
+
 <a name="v0.27.0"></a>
-## [v0.27.0] - 2024-10-22
+## [v0.27.0] - 2024-10-23
 
 <a name="v0.26.0"></a>
 ## [v0.26.0] - 2024-10-21
@@ -143,7 +146,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v0.28.0...HEAD
+[v0.28.0]: https://github.com/grafana/grafana-build-tools/compare/v0.27.0...v0.28.0
 [v0.27.0]: https://github.com/grafana/grafana-build-tools/compare/v0.26.0...v0.27.0
 [v0.26.0]: https://github.com/grafana/grafana-build-tools/compare/v0.25.0...v0.26.0
 [v0.25.0]: https://github.com/grafana/grafana-build-tools/compare/v0.24.0...v0.25.0


### PR DESCRIPTION
* Update renovate configuration
* Disable pinning of docker dependencies
* Try to workaround renovate bugs
* Another try at disabling pinned digests
* "docker" is not a manager...
* Yet another try at convincing renovate to not pin digests...
* And yet another try at convincing renovate to not pin digests...
* Try again with autoReplaceStringTemplate
* Update dependency nfpm to v2.41.0
* Renovate wants digests
* Update dependency golangci-lint to v1.61.0
* Update dependency lefthook to v1.8.1