### PR TITLE
Release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 ## [Unreleased]
 
 
+<a name="v0.36.0"></a>
+## [v0.36.0] - 2025-01-13
+
 <a name="v0.35.1"></a>
-## [v0.35.1] - 2025-01-07
+## [v0.35.1] - 2025-01-08
 
 <a name="v0.35.0"></a>
 ## [v0.35.0] - 2025-01-06
@@ -189,7 +192,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v0.35.1...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v0.36.0...HEAD
+[v0.36.0]: https://github.com/grafana/grafana-build-tools/compare/v0.35.1...v0.36.0
 [v0.35.1]: https://github.com/grafana/grafana-build-tools/compare/v0.35.0...v0.35.1
 [v0.35.0]: https://github.com/grafana/grafana-build-tools/compare/v0.34.0...v0.35.0
 [v0.34.0]: https://github.com/grafana/grafana-build-tools/compare/v0.33.2...v0.34.0


### PR DESCRIPTION
* Update dependency xk6 to v0.13.4 (#226)
* Update dependency lefthook to v1.10.0 (#220)
* Set persist-credentials to false (#230)
* Update dependency golangci-lint to v1.63.4 (#223)
* Update dependency chglog to v0.6.2 (#228)
* Update dependency lefthook to v1.10.2 (#229)
* Update dependency buf to v1.48.0 (#219)
* Update dependency lefthook to v1.10.4 (#233)
* Update dependency yq to v4.45.1 (#232)
* Update dependency nfpm to v2.41.2 (#231)