### PR TITLE
fix: Add automerge settings to renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,16 @@
     "pinDigests": false
   },
 
+  "automerge": true,
+  "assignAutomerge": true,
+  "assigneesFromCodeOwners": true,
+  "automergeStrategy": "squash",
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "pruneBranchAfterAutomerge": true,
+
+  "commitMessagePrefix": "chore:",
+
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
As with so many other things renovate, this is likely not going to do what I'm expecting...