### PR TITLE
feat: Add golangci-lint-v2

### DIFF
--- a/Dockerfile.build.tmpl
+++ b/Dockerfile.build.tmpl
@@ -131,6 +131,13 @@ FROM go AS golangci_lint
 
 	RUN env GOPATH=/build GOOS=${TARGET_GOOS} GOARCH=${TARGET_GOARCH} go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{ .data.golangci_lint }}
 
+FROM go AS golangci_lint_v2
+	ARG TARGET_GOOS
+	ARG TARGET_GOARCH
+
+	RUN env GOPATH=/build GOOS=${TARGET_GOOS} GOARCH=${TARGET_GOARCH} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{ .data.golangci_lint_v2 }} && \
+		mv /build/bin/golangci-lint /build/bin/golangci-lint-v2
+
 FROM go AS gomplate
 	ARG TARGET_GOOS
 	ARG TARGET_GOARCH
@@ -234,7 +241,9 @@ FROM docker.io/library/debian:stable-slim AS final
 	COPY --from=go_jsonnet /build/bin/* /dist/
 	
 	COPY --from=golangci_lint /build/bin/* /dist/
-	
+
+	COPY --from=golangci_lint_v2 /build/bin/* /dist/
+
 	COPY --from=gomplate /build/bin/* /dist/
 
 	COPY --from=gotestsum /build/bin/* /dist/

--- a/lib/image-test
+++ b/lib/image-test
@@ -81,6 +81,9 @@ grr --version
 echo '=== golangci-lint'
 golangci-lint version
 
+echo '=== golangci-lint-v2'
+golangci-lint-v2 version
+
 echo '=== gomplate'
 gomplate --version
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,8 +32,9 @@ gh: v2.60.1
 git_chglog: v0.15.4
 # renovate: datasource=docker depName=go packageName=golang
 go: 1.24.4 # sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c
-# renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
 golangci_lint: v1.64.8
+# renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
+golangci_lint_v2: v2.1.6
 # renovate: datasource=github-releases depName=gomplate packageName=hairyhenderson/gomplate
 gomplate: v4.3.2
 # renovate: datasource=github-releases depName=gotest.tools/gotestsum packageName=gotestyourself/gotestsum


### PR DESCRIPTION
Keep golangci-lint in the image to avoid breaking backwards compatibility with existing users. Add golangci-lint-v2 to create an upgrade path.