### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v1.7.2"></a>
+## [v1.7.2] - 2025-06-10
+### Bug Fixes
+- Handle different architectures when renaming golangci-lint
+
+
 <a name="v1.7.1"></a>
 ## [v1.7.1] - 2025-06-10
 ### Bug Fixes
@@ -292,7 +298,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.7.2...HEAD
+[v1.7.2]: https://github.com/grafana/grafana-build-tools/compare/v1.7.1...v1.7.2
 [v1.7.1]: https://github.com/grafana/grafana-build-tools/compare/v1.7.0...v1.7.1
 [v1.7.0]: https://github.com/grafana/grafana-build-tools/compare/v1.6.0...v1.7.0
 [v1.6.0]: https://github.com/grafana/grafana-build-tools/compare/v1.5.6...v1.6.0


### PR DESCRIPTION
* fix: Handle different architectures when renaming golangci-lint