### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## [Unreleased]
 
 
+<a name="v1.8.0"></a>
+## [v1.8.0] - 2025-07-04
+
 <a name="v1.7.3"></a>
 ## [v1.7.3] - 2025-06-11
 ### Bug Fixes
@@ -304,7 +307,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.7.3...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.8.0...HEAD
+[v1.8.0]: https://github.com/grafana/grafana-build-tools/compare/v1.7.3...v1.8.0
 [v1.7.3]: https://github.com/grafana/grafana-build-tools/compare/v1.7.2...v1.7.3
 [v1.7.2]: https://github.com/grafana/grafana-build-tools/compare/v1.7.1...v1.7.2
 [v1.7.1]: https://github.com/grafana/grafana-build-tools/compare/v1.7.0...v1.7.1


### PR DESCRIPTION
* chore: Update dependency buf to v1.55.0 (#348)
* chore: Update dependency lefthook to v1.11.14 (#347)
* chore: Update dependency lefthook to v1.11.16 (#354)
* chore: Update jq Docker tag to v1.8.1 (#353)
* chore: Update dependency k6 to v1.1.0 (#351)
* chore: Update dependency gotest.tools/gotestsum to v1.12.3 (#350)
* chore: Update dependency buf to v1.55.1 (#349)
* chore: Update dependency xk6 to v1 (#343)
* chore: Update dependency golangci-lint to v2.2.1 (#352)