### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v1.9.0"></a>
+## [v1.9.0] - 2025-07-09
+### Features
+- Update to Go 1.24.5
+
+
 <a name="v1.8.0"></a>
 ## [v1.8.0] - 2025-07-04
 
@@ -307,7 +313,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.9.0...HEAD
+[v1.9.0]: https://github.com/grafana/grafana-build-tools/compare/v1.8.0...v1.9.0
 [v1.8.0]: https://github.com/grafana/grafana-build-tools/compare/v1.7.3...v1.8.0
 [v1.7.3]: https://github.com/grafana/grafana-build-tools/compare/v1.7.2...v1.7.3
 [v1.7.2]: https://github.com/grafana/grafana-build-tools/compare/v1.7.1...v1.7.2


### PR DESCRIPTION
* chore: Update dependency lefthook to v1.12.0 (#356)
* feat: Update to Go 1.24.5