### PR TITLE
feat: Add Spectral to the image

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM docker.io/library/golang:{{ .data.go }} AS go
 	COPY lib/go.env /usr/local/go/
 	RUN mkdir -p /build/bin
 
-{{- $skip := dict "go" true "k6" true "skopeo" true "shellcheck" true "jq" true -}}
+{{- $skip := dict "go" true "k6" true "skopeo" true "shellcheck" true "jq" true "spectral" true -}}
 
 {{ range $pkg, $info := .data }}
 {{ if not (index $skip $pkg) }}
@@ -55,6 +55,14 @@ FROM scratch AS shellcheck
 
 FROM scratch AS jq
 	COPY --from=ghcr.io/jqlang/jq:1.7.1 /jq /build/bin/
+
+FROM go AS spectral
+	ARG TARGET_GOOS
+	ARG TARGET_GOARCH
+
+	COPY build/spectral /tmp/build
+
+	RUN "/tmp/build" "{{ .data.spectral }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
 
 FROM docker.io/library/debian:stable-slim AS final
     RUN apt-get update && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM docker.io/library/golang:{{ .data.go }} AS go
 	COPY lib/go.env /usr/local/go/
 	RUN mkdir -p /build/bin
 
-{{- $skip := dict "go" true "k6" true "skopeo" true "shellcheck" true "jq" true "spectral" true -}}
+{{- $skip := dict "go" true "k6" true "skopeo" true "shellcheck" true "jq" true -}}
 
 {{ range $pkg, $info := .data }}
 {{ if not (index $skip $pkg) }}
@@ -55,14 +55,6 @@ FROM scratch AS shellcheck
 
 FROM scratch AS jq
 	COPY --from=ghcr.io/jqlang/jq:1.7.1 /jq /build/bin/
-
-FROM go AS spectral
-	ARG TARGET_GOOS
-	ARG TARGET_GOARCH
-
-	COPY build/spectral /tmp/build
-
-	RUN "/tmp/build" "{{ .data.spectral }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
 
 FROM docker.io/library/debian:stable-slim AS final
     RUN apt-get update && \

--- a/build/spectral
+++ b/build/spectral
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+set -u
+
+# download Spectral binary for the target OS and architecture
+case "${2}" in
+    "linux")
+        case "${3}" in
+            "amd64")
+                ARCH="x64"
+                ;;
+            "arm64")
+                ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture: ${3}"
+                exit 1
+                ;;
+        esac
+        ;;
+    "darwin")
+        case "${3}" in
+            "amd64")
+                ARCH="x64"
+                ;;
+            "arm64")
+                ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture: ${3}"
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported OS: ${2}"
+        exit 1
+        ;;
+esac
+
+# download Spectral binary
+curl -L "https://github.com/stoplightio/spectral/releases/download/${1}/spectral-${2}-${ARCH}" -o /tmp/spectral
+chmod +x /tmp/spectral
+
+mkdir -p /build/bin
+cp /tmp/spectral /build/bin/spectral

--- a/lib/image-test
+++ b/lib/image-test
@@ -122,6 +122,9 @@ skopeo --version
 echo '=== yq'
 yq --version
 
+echo '=== spectral'
+spectral --version
+
 echo '=== get-latest-gbt-version'
 command -v get-latest-gbt-version
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -99,6 +99,9 @@ skopeo: v1.20.0
 # renovate: datasource=github-releases depName=wire packageName=google/wire
 wire: v0.6.0
 
+# renovate: datasource=github-releases depName=spectral packageName=stoplightio/spectral
+spectral: v6.15.0
+
 # renovate: datasource=github-tags depName=xk6 packageName=grafana/xk6
 xk6: v1.1.2
 


### PR DESCRIPTION
Related to https://github.com/grafana/synthetic-monitoring-api/issues/1512

Spectral is a JSON/YAML linter with OOTB support for OpenAPI 3.x.

Add it to the image so we can use it in linting steps for the Synthetic Monitoring OpenAPI spec.

This is needed so I can get https://github.com/grafana/synthetic-monitoring-api/pull/1548 working in CI. I think the docker-in-docker situation is getting in the way of easily using the `stoplight/spectral` image to lint in CI.