### PR TITLE
feat: Update to Go 1.25.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -40,7 +40,7 @@ gh: v2.60.1
 git_chglog: v0.15.4
 
 # renovate: datasource=docker depName=go packageName=golang
-go: 1.24.6 # sha256:2c89c41fb9efc3807029b59af69645867cfe978d2b877d475be0d72f6c6ce6f6
+go: 1.25.0 # sha256:91e2cd436f7adbfad0a0cbb7bf8502fa863ed8461414ceebe36c6304731e0fd9
 
 golangci_lint: v1.64.8
 


### PR DESCRIPTION
This removes wire, because the project is unmaintained and it's not clear if there's a replacement. grafana/grafana has its own internal fork, which it uses as part of the build process.