### PR TITLE
feat: Add golangci-lint wrapper

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -74,6 +74,8 @@ FROM docker.io/library/debian:stable-slim AS final
 
     COPY lib/image-test /usr/local/bin
 
+    COPY lib/golangci-lint /usr/local/bin
+
     COPY lib/get-latest-gbt-version /usr/local/bin
 
     COPY --from=go /usr/local/go /usr/local/go

--- a/build/golangci_lint
+++ b/build/golangci_lint
@@ -6,4 +6,14 @@ set -u
 apt update
 apt install -y binutils-gold binutils
 
-env GOPATH=/build GOOS="${2}" GOARCH="${3}" go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${1}"
+GOPATH=${4:-"/build"}
+
+env GOPATH="${GOPATH}" GOOS="${2}" GOARCH="${3}" go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${1}"
+
+# For native builds, the binary is found in build/bin/golangci-lint,
+# but for cross builds, it is found in
+# build/bin/${TARGET_GOOS}-${TARGET_GOARCH}/golangci-lint.
+#
+# Play some games with find and xargs to rename the binary to
+# golangci-lint-v1 regardless of the architecture.
+find "${GOPATH}/bin/" -name golangci-lint -print0 | xargs -I{} -r0 mv -v '{}' '{}-v1'

--- a/build/golangci_lint_v2
+++ b/build/golangci_lint_v2
@@ -8,7 +8,7 @@ apt install -y binutils-gold binutils
 
 GOPATH=${4:-"/build"}
 
-env GOPATH=${GOPATH} GOOS="${2}" GOARCH="${3}" go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${1}"
+env GOPATH="${GOPATH}" GOOS="${2}" GOARCH="${3}" go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${1}"
 
 # For native builds, the binary is found in build/bin/golangci-lint,
 # but for cross builds, it is found in
@@ -16,4 +16,4 @@ env GOPATH=${GOPATH} GOOS="${2}" GOARCH="${3}" go install "github.com/golangci/g
 #
 # Play some games with find and xargs to rename the binary to
 # golangci-lint-v2 regardless of the architecture.
-find ${GOPATH}/bin/ -name golangci-lint -print0 | xargs -I{} -r0 mv -v '{}' '{}-v2'
+find "${GOPATH}/bin/" -name golangci-lint -print0 | xargs -I{} -r0 mv -v '{}' '{}-v2'

--- a/lib/golangci-lint
+++ b/lib/golangci-lint
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# This is a wrapper around golangci-lint that selects the correct version of
+# golangci-lint based on the version specified in the configuration file.
+#
+# This is needed because the configuration file format changed with version 2,
+# and it's neither forwards- nor backwards-compatible, and they decided to keep
+# the same filename for both versions.
+
+set -e
+set -u
+
+# Assume version 1 of golangci-lint is able to locate the configuration file.
+# This command fails with version 2 because it tries to validate the file.
+config_file=$(golangci-lint-v1 config path 2>&1 || true)
+
+if test -z "${config_file}" -o ! -e "${config_file}" ; then
+	echo "E: golangci-lint config file not found. Stop."
+	exit 1
+fi
+
+config_file_version=$(yq '.version' "${config_file}")
+
+case "${config_file_version}" in
+	2)
+		# We have version 2
+		golangci_lint=golangci-lint-v2
+		;;
+
+	null|1)
+		# We have version 1
+		golangci_lint=golangci-lint-v1
+	;;
+
+	*)
+		echo "E: Found version '${config_file_version}' in configuration file ${config_file}. I don't know how to handle that. Stop."
+		exit 1
+	;;
+esac
+
+exec "${golangci_lint}" "$@"

--- a/lib/image-test
+++ b/lib/image-test
@@ -78,8 +78,8 @@ sqlc version
 echo '=== grr'
 grr --version
 
-echo '=== golangci-lint'
-golangci-lint version
+echo '=== golangci-lint-v1'
+golangci-lint-v1 version
 
 echo '=== golangci-lint-v2'
 golangci-lint-v2 version


### PR DESCRIPTION
It's not perfect, and it's making some assumptions, but it should be enough to allow existing setups to work regardless of whether they have migrated the configuration file or not.