### PR TITLE
Release v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v1.18.0"></a>
+## [v1.18.0] - 2025-08-19
+### Features
+- Update to Go 1.25.0
+
+
 <a name="v1.17.0"></a>
 ## [v1.17.0] - 2025-08-29
 
@@ -366,7 +372,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.17.0...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.18.0...HEAD
+[v1.18.0]: https://github.com/grafana/grafana-build-tools/compare/v1.17.0...v1.18.0
 [v1.17.0]: https://github.com/grafana/grafana-build-tools/compare/v1.16.1...v1.17.0
 [v1.16.1]: https://github.com/grafana/grafana-build-tools/compare/v1.16.0...v1.16.1
 [v1.16.0]: https://github.com/grafana/grafana-build-tools/compare/v1.15.0...v1.16.0


### PR DESCRIPTION
* feat: Update to Go 1.25.0

The commit that updates Go to 1.25.0 states that wire was removed. This is incorrect.