### PR TITLE
fix: Use a sane configuration format for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,34 +4,19 @@
     "config:best-practices",
     ":semanticCommitsDisabled"
   ],
-
   "enabled": false,
-
-  "branchPrefix": "grafanarenovatebot/",
-  "platformCommit": "enabled",
   "dependencyDashboard": false,
+  "branchPrefix": "grafanarenovatebot/",
+  "commitMessagePrefix": "chore:",
+  "platformCommit": "enabled",
   "forkProcessing": "enabled",
   "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
   "branchConcurrentLimit": 10,
-
-  "enabledManagers": ["custom.regex", "gomod"],
-
-  "labels": ["dependencies"],
-
-  "gomod": {
-    "enabled": true
-  },
-
-  "postUpdateOptions": [
-    "gomodTidyE"
+  "labels": [
+    "dependencies"
   ],
-
-  "regex": {
-    "pinDigests": false
-  },
-
   "automerge": true,
   "assignAutomerge": true,
   "assigneesFromCodeOwners": true,
@@ -39,31 +24,50 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "pruneBranchAfterAutomerge": true,
-
-  "commitMessagePrefix": "chore:",
-
+  "enabledManagers": [
+    "custom.regex",
+    "gomod"
+  ],
+  "gomod": {
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "gomodTidyE"
+  ],
+  "regex": {
+    "pinDigests": false
+  },
   "packageRules": [
     {
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["digest"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
       "schedule": "before 8am on monday every 2 weeks"
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": [
+        "gomod"
+      ],
       "matchPackageNames": "github.com/prometheus/*",
       "groupName": "prometheus-go"
     },
     {
-      "matchCategories": ["docker"],
+      "matchCategories": [
+        "docker"
+      ],
       "pinDigests": false
     }
   ],
-
   "customManagers": [
     {
       "customType": "regex",
       "description": "update docker versions found in versions.yaml",
-      "fileMatch": [ "^versions\\.yaml$" ],
+      "managerFilePatterns": [
+        "/^versions\\.yaml$/"
+      ],
       "datasourceTemplate": "docker",
       "autoReplaceStringTemplate": "# renovate: datasource=docker packageName={{packageName}}{{{versioningStr}}}\n{{depName}}: {{newValue}} # {{newDigest}}\n",
       "matchStrings": [
@@ -73,7 +77,9 @@
     {
       "customType": "regex",
       "description": "update versions found in versions.yaml",
-      "fileMatch": [ "^versions\\.yaml$" ],
+      "managerFilePatterns": [
+        "/^versions\\.yaml$/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>github-releases|github-tags|go) (?:depName=(?<depName>.+?) )?packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:[-a-zA-Z0-9_]+:) (?<currentValue>.+?)\\s"
       ]

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -1,0 +1,78 @@
+$schema: https://docs.renovatebot.com/renovate-schema.json
+
+extends:
+  - config:best-practices
+  - :semanticCommitsDisabled
+
+# This repo is public, so prevent the Mend Renovate app from trying to create
+# PRs here by setting enabled to false.
+enabled: false
+dependencyDashboard: false
+
+branchPrefix: grafanarenovatebot/
+commitMessagePrefix: 'chore:'
+platformCommit: enabled
+forkProcessing: enabled
+rebaseWhen: behind-base-branch
+prHourlyLimit: 0
+prConcurrentLimit: 10
+branchConcurrentLimit: 10
+labels:
+  - dependencies
+
+# Automerge settings
+automerge: true
+assignAutomerge: true
+assigneesFromCodeOwners: true
+automergeStrategy: squash
+automergeType: pr
+platformAutomerge: true
+pruneBranchAfterAutomerge: true
+
+enabledManagers:
+  - custom.regex
+  - gomod
+
+gomod:
+  enabled: true
+
+postUpdateOptions:
+  - gomodTidyE
+
+regex:
+  pinDigests: false
+
+packageRules:
+  - matchManagers:
+      - gomod
+    matchUpdateTypes:
+      - digest
+    schedule: before 8am on monday every 2 weeks
+
+  - matchManagers:
+      - gomod
+    matchPackageNames: github.com/prometheus/*
+    groupName: prometheus-go
+
+  - matchCategories:
+      - docker
+    pinDigests: false
+
+customManagers:
+  - customType: regex
+    description: update docker versions found in versions.yaml
+    managerFilePatterns:
+      - /^versions\.yaml$/
+    datasourceTemplate: docker
+    autoReplaceStringTemplate: |
+      # renovate: datasource=docker packageName={{packageName}}{{{versioningStr}}}
+      {{depName}}: {{newValue}} # {{newDigest}}
+    matchStrings:
+      - '# renovate: datasource=docker packageName=(?<packageName>.+?)(?<versioningStr> versioning=(?<versioning>[a-z-]+?))?\s(?<depName>[-a-zA-Z0-9_]+): (?<currentValue>.+?)( # (?<currentDigest>sha256:[a-f0-9]+))?\s'
+
+  - customType: regex
+    description: update versions found in versions.yaml
+    managerFilePatterns:
+      - /^versions\.yaml$/
+    matchStrings:
+      - '# renovate: datasource=(?<datasource>github-releases|github-tags|go) (?:depName=(?<depName>.+?) )?packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\s(?:[-a-zA-Z0-9_]+:) (?<currentValue>.+?)\s'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@a889a8abcb11ef7feaafaf5e483ea01d4bf7774e # v43.0.5
         with:
-          renovate-version: 39.23.0
+          renovate-version: 41.97.9
           configurationFile: .github/renovate-app.json
           token: '${{ steps.app-token.outputs.token }}'
           docker-cmd-file: .github/renovate

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -1,0 +1,58 @@
+name: Validate renovate config
+on:
+  pull_request:
+    paths:
+      # When renovate config changes:
+      - "renovate.*"
+      - ".renovate.*"
+      - ".github/renovate.*"
+      # Also when renovate version changes:
+      - ".github/workflows/renovate*"
+
+permissions:
+  contents: none
+
+jobs:
+  enforce-code-generation:
+    name: enforce code generation
+    runs-on:
+      - ubuntu-arm64
+    container:
+      image: ghcr.io/grafana/grafana-build-tools:1.19.0@sha256:f481a21faac22170b89a11baadb6d633cc05dcde7c7d4ee2f9e170b943698c12
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          fetch-tags: false
+
+      - name: Set up global git config
+        run: |
+          # The directory where the code has been checked out ends up belonging
+          # to a different user, so git complains about permissions. Indicate
+          # that it's safe to ignore.
+          git config --global --add safe.directory '*'
+
+      - name: generate configuration file
+        run: |
+          make .github/renovate.json
+          scripts/enforce-clean
+
+  validate-renovate:
+    name: validate renovate configuration
+    permissions:
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Self-hosted renovate
+        uses: grafana/sm-renovate/actions/renovate-validate@main

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ tag: ## print out the tag
 		echo $(IMAGE_TAG)-$(TARGET_ARCHES) ;\
 	fi
 
+.github/renovate.json: .github/renovate.yaml
+	@echo "Generating $@..."
+	$(S) yq --output-format j '$<' > '$@'
+
 .PHONY: help
 help: ## display this help.
 	$(S) awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/scripts/enforce-clean
+++ b/scripts/enforce-clean
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# This script verifies that files that might change after some updates
+# (e.g. upgrading a dependency) DO NOT contain changes.
+#
+# Typical usage is calling this script after some continuous integration
+# step that could produce such changes.
+#
+# If any unwanted changes are detected, the exit status will be 1, 0
+# otherwise.
+
+set -e
+
+report_changes() {
+	echo "E: $1 contains changes. Stop."
+	exit 1
+}
+
+test -n "$(git status --porcelain -- go.sum)" && report_changes go.sum
+
+exit 0


### PR DESCRIPTION
No problem resists enough levels of indirection. Renovate's configuration formats (JSON or its evil cousin JSON5) are unfriendly towards humans, and in particular the need for escaping certain things within strings makes things harder to read. The fact that renovate uses _regular expressions_ within strings makes things worse because, unless you are doing something trivial, you are almost guaranteed to use backslashes.

Instead of trying to deal