### PR TITLE
fix: rework versions file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,9 +69,9 @@
         "/^versions\\.yaml$/"
       ],
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "# renovate: datasource=docker packageName={{packageName}}{{{versioningStr}}}\n{{depName}}: {{newValue}} # {{newDigest}}\n",
+      "autoReplaceStringTemplate": "version: {{newValue}} # {{newDigest}}{{{renovateStr}}}",
       "matchStrings": [
-        "# renovate: datasource=docker packageName=(?<packageName>.+?)(?<versioningStr> versioning=(?<versioning>[a-z-]+?))?\\s(?<depName>[-a-zA-Z0-9_]+): (?<currentValue>.+?)( # (?<currentDigest>sha256:[a-f0-9]+))?\\s"
+        "\\bversion: (?<currentValue>.+?) # (?<currentDigest>sha256:[a-f0-9]+)(?<renovateStr> # renovate: datasource=docker(?:[ \\t]+depName=(?<depName>[-_./\\w]+))?(?:[ \\t]+packageName=(?<packageName>[-_./\\w]+))(?:[ \\t]+versioning=(?<versioning>[-_./\\w]+?))?)"
       ]
     },
     {
@@ -80,8 +80,9 @@
       "managerFilePatterns": [
         "/^versions\\.yaml$/"
       ],
+      "autoReplaceStringTemplate": "version: {{newValue}}{{{renovateStr}}}",
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>github-releases|github-tags|go) (?:depName=(?<depName>.+?) )?packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:[-a-zA-Z0-9_]+:) (?<currentValue>.+?)\\s"
+        "\\bversion: (?<currentValue>.+?)(?<renovateStr> # renovate: datasource=(?<datasource>github-releases|github-tags|go)(?:[ \\t]+depName=(?<depName>[-_./\\w]+))?(?:[ \\t]+packageName=(?<packageName>[-_./\\w]+))(?:[ \\t]+versioning=(?<versioning>[-_./\\w]+?))?)"
       ]
     }
   ]

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -64,15 +64,18 @@ customManagers:
     managerFilePatterns:
       - /^versions\.yaml$/
     datasourceTemplate: docker
-    autoReplaceStringTemplate: |
-      # renovate: datasource=docker packageName={{packageName}}{{{versioningStr}}}
-      {{depName}}: {{newValue}} # {{newDigest}}
+    autoReplaceStringTemplate: |-
+      version: {{newValue}} # {{newDigest}}{{{renovateStr}}}
     matchStrings:
-      - '# renovate: datasource=docker packageName=(?<packageName>.+?)(?<versioningStr> versioning=(?<versioning>[a-z-]+?))?\s(?<depName>[-a-zA-Z0-9_]+): (?<currentValue>.+?)( # (?<currentDigest>sha256:[a-f0-9]+))?\s'
+      # Beware that renovate will include newlines in \s because it uses 'g'.
+      - '\bversion: (?<currentValue>.+?) # (?<currentDigest>sha256:[a-f0-9]+)(?<renovateStr> # renovate: datasource=docker(?:[ \t]+depName=(?<depName>[-_./\w]+))?(?:[ \t]+packageName=(?<packageName>[-_./\w]+))(?:[ \t]+versioning=(?<versioning>[-_./\w]+?))?)'
 
   - customType: regex
     description: update versions found in versions.yaml
     managerFilePatterns:
       - /^versions\.yaml$/
+    autoReplaceStringTemplate: |-
+      version: {{newValue}}{{{renovateStr}}}
     matchStrings:
-      - '# renovate: datasource=(?<datasource>github-releases|github-tags|go) (?:depName=(?<depName>.+?) )?packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\s(?:[-a-zA-Z0-9_]+:) (?<currentValue>.+?)\s'
+      # Beware that renovate will include newlines in \s because it uses 'g'.
+      - '\bversion: (?<currentValue>.+?)(?<renovateStr> # renovate: datasource=(?<datasource>github-releases|github-tags|go)(?:[ \t]+depName=(?<depName>[-_./\w]+))?(?:[ \t]+packageName=(?<packageName>[-_./\w]+))(?:[ \t]+versioning=(?<versioning>[-_./\w]+?))?)'

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -1,18 +1,16 @@
-FROM docker.io/library/golang:{{ .data.go }} AS go
+FROM docker.io/library/golang:{{ .data.go.version }} AS go
 	COPY lib/go.env /usr/local/go/
 	RUN mkdir -p /build/bin
 
-{{- $skip := dict "go" true "k6" true "skopeo" true "shellcheck" true "jq" true -}}
-
 {{ range $pkg, $info := .data }}
-{{ if not (index $skip $pkg) }}
+{{ if (not (index $info "custom_build")) }}
 FROM go AS {{ $pkg }}
 	ARG TARGET_GOOS
 	ARG TARGET_GOARCH
 
 	COPY build/{{ $pkg }} /tmp/build
 
-	RUN "/tmp/build" "{{ $info }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
+	RUN "/tmp/build" "{{ $info.version }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
 {{- end }}
 {{- end }}
 
@@ -22,7 +20,7 @@ FROM xk6 AS k6
 
 	COPY build/k6 /tmp/build
 
-	RUN "/tmp/build" "{{ .data.k6 }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
+	RUN "/tmp/build" "{{ .data.k6.version }}" "${TARGET_GOOS}" "${TARGET_GOARCH}"
 
 FROM docker.io/library/debian:stable-slim AS skopeo
 	ARG TARGET_GOOS
@@ -45,16 +43,16 @@ FROM docker.io/library/debian:stable-slim AS skopeo
 	# inspect the available versions without pulling the repos.
 	RUN git clone https://github.com/containers/skopeo && \
 	    cd skopeo && \
-	    git checkout "{{ .data.skopeo }}" && \
+	    git checkout "{{ .data.skopeo.version }}" && \
 	    make GOPATH=/build DISABLE_DOCS=1 bin/skopeo.${TARGET_GOOS}.${TARGET_GOARCH} && \
 	    mkdir -p /build/bin && \
 	    cp bin/skopeo.${TARGET_GOOS}.${TARGET_GOARCH} /build/bin/skopeo
 
 FROM scratch AS shellcheck
-	COPY --from=docker.io/koalaman/shellcheck:v0.10.0 /bin/shellcheck /build/bin/
+	COPY --from=docker.io/koalaman/shellcheck:{{ .data.shellcheck.version }} /bin/shellcheck /build/bin/
 
 FROM scratch AS jq
-	COPY --from=ghcr.io/jqlang/jq:1.7.1 /jq /build/bin/
+	COPY --from=ghcr.io/jqlang/jq:{{ .data.jq.version }} /jq /build/bin/
 
 FROM docker.io/library/debian:stable-slim AS final
     RUN apt-get update && \
@@ -81,7 +79,9 @@ FROM docker.io/library/debian:stable-slim AS final
     COPY --from=go /usr/local/go /usr/local/go
 
     {{ range $pkg, $info := .data }}
+    {{ if (not (index $info "custom_install")) }}
     COPY --from={{ $pkg }} /build/bin/* /usr/local/bin/
+    {{ end }}
     {{ end }}
 
     ENV PATH="/usr/local/go/bin:${PATH}"

--- a/scripts/enforce-clean
+++ b/scripts/enforce-clean
@@ -12,10 +12,13 @@
 set -e
 
 report_changes() {
-	echo "E: $1 contains changes. Stop."
+	git status --porcelain --untracked-files=no | cut -c4- | while read -r fn ; do
+		echo "W: $fn contains changes."
+	done
+	echo "E: Changes detected. Stop."
 	exit 1
 }
 
-test -n "$(git status --porcelain -- go.sum)" && report_changes go.sum
+test -n "$(git status --porcelain --untracked-files=no)" && report_changes
 
 exit 0

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,7 +1,5 @@
-# This file is formatted so that renovate can update it. The lines must start
-# with a hash, followed by the ` renovate: ` literal, and then a sequence of
-# datasource, depName (optional), packageName and versioning (optional)
-# settings.
+# This file is formatted so that renovate can update it. Keep the '# renovate:'
+# comments where they are.
 #
 # DO NOT follow the suggestion at
 # https://docs.renovatebot.com/modules/manager/regex/#advanced-capture, which
@@ -12,98 +10,108 @@
 # image. The makefile is written in a way so that make will notice the change
 # and rebuild the Dockerfile before rebuilding the image.
 
-# renovate: datasource=github-releases depName=actionlint packageName=rhysd/actionlint
-actionlint: v1.7.7
+actionlint:
+  version: v1.7.7 # renovate: datasource=github-releases depName=actionlint packageName=rhysd/actionlint
 
-# renovate: datasource=github-releases depName=bingo packageName=bwplotka/bingo
-bingo: v0.9.0
+bingo:
+  version: v0.9.0 # renovate: datasource=github-releases depName=bingo packageName=bwplotka/bingo
 
-# renovate: datasource=github-releases depName=chglog packageName=goreleaser/chglog
-chglog: v0.7.3
+chglog:
+  version: v0.7.3 # renovate: datasource=github-releases depName=chglog packageName=goreleaser/chglog
 
-# renovate: datasource=github-releases depName=lefthook packageName=evilmartians/lefthook
-lefthook: v1.13.1
+lefthook:
+  version: v1.13.1 # renovate: datasource=github-releases depName=lefthook packageName=evilmartians/lefthook
 
-# renovate: datasource=github-releases depName=buf packageName=bufbuild/buf
-buf: v1.57.2
+buf:
+  version: v1.57.2 # renovate: datasource=github-releases depName=buf packageName=bufbuild/buf
 
-# renovate: datasource=github-releases depName=dockerfile-json packageName=keilerkonzept/dockerfile-json
-dockerfile_json: v1.2.2
+dockerfile_json:
+  version: v1.2.2 # renovate: datasource=github-releases depName=dockerfile-json packageName=keilerkonzept/dockerfile-json
 
-# renovate: datasource=github-tags depName=enumer packageName=dmarkham/enumer
-enumer: v1.6.1
+enumer:
+  version: v1.6.1 # renovate: datasource=github-tags depName=enumer packageName=dmarkham/enumer
 
-# renovate: datasource=github-releases depName=gh packageName=github.com/cli/cli
-gh: v2.60.1
+gh:
+  version: v2.60.1 # renovate: datasource=github-releases depName=gh packageName=github.com/cli/cli
 
-# renovate: datasource=github-tags depName=git-chglog packageName=git-chglog/git-chglog
-git_chglog: v0.15.4
+git_chglog:
+  version: v0.15.4 # renovate: datasource=github-tags depName=git-chglog packageName=git-chglog/git-chglog
 
-# renovate: datasource=docker depName=go packageName=golang
-go: 1.25.1 # sha256:0802d0e17ff58ee90d2dc9cd5da4f502b3d4d12677096ad73fd9a505f222781b
+go:
+  custom_build: true
+  custom_install: true
+  version: 1.25.1 # sha256:0802d0e17ff58ee90d2dc9cd5da4f502b3d4d12677096ad73fd9a505f222781b # renovate: datasource=docker depName=go packageName=golang
 
-golangci_lint: v1.64.8
+golangci_lint:
+  version: v1.64.8
 
-# renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
-golangci_lint_v2: v2.4.0
+golangci_lint_v2:
+  version: v2.4.0 # renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
 
-# renovate: datasource=github-releases depName=gomplate packageName=hairyhenderson/gomplate
-gomplate: v4.3.3
+gomplate:
+  version: v4.3.3 # renovate: datasource=github-releases depName=gomplate packageName=hairyhenderson/gomplate
 
-# renovate: datasource=github-releases depName=gotest.tools/gotestsum packageName=gotestyourself/gotestsum
-gotestsum: v1.13.0
-grizzly: v0.4.3
+gotestsum:
+  version: v1.13.0 # renovate: datasource=github-releases depName=gotest.tools/gotestsum packageName=gotestyourself/gotestsum
 
-# renovate: datasource=docker packageName=ghcr.io/jqlang/jq
-jq: 1.8.1 # sha256:4f34c6d23f4b1372ac789752cc955dc67c2ae177eb1b5860b75cdc5091ce6f91
+grizzly:
+  version: v0.4.3
 
-# renovate: datasource=github-releases depName=go-jsonnet packageName=google/go-jsonnet
-go_jsonnet: v0.21.0
+jq:
+  custom_build: true
+  version: 1.8.1 # sha256:4f34c6d23f4b1372ac789752cc955dc67c2ae177eb1b5860b75cdc5091ce6f91 # renovate: datasource=docker depName=jq packageName=ghcr.io/jqlang/jq
 
-# renovate: datasource=github-releases depName=k6 packageName=grafana/k6
-k6: v1.2.3
+go_jsonnet:
+  version: v0.21.0 # renovate: datasource=github-releases depName=go-jsonnet packageName=google/go-jsonnet
 
-# renovate: datasource=github-tags depName=mage packageName=magefile/mage
-mage: v1.15.0
+k6:
+  custom_build: true
+  version: v1.2.3 # renovate: datasource=github-releases depName=k6 packageName=grafana/k6
 
-# renovate: datasource=github-releases depName=migrate packageName=golang-migrate/migrate
-migrate: v4.19.0
+mage:
+  version: v1.15.0 # renovate: datasource=github-tags depName=mage packageName=magefile/mage
 
-# renovate: datasource=github-releases depName=nfpm packageName=goreleaser/nfpm
-nfpm: v2.43.1
+migrate:
+  version: v4.19.0 # renovate: datasource=github-releases depName=migrate packageName=golang-migrate/migrate
 
-# This hasn't been released yet, so pin it to a specific version for reproducibility
-nilaway: v0.0.0-20250722134535-afb472521551
+nfpm:
+  version: v2.43.1 # renovate: datasource=github-releases depName=nfpm packageName=goreleaser/nfpm
 
-# renovate: datasource=github-releases depName=oapi-codegen packageName=github.com/oapi-codegen/oapi-codegen
-oapi_codegen: v2.4.1
+nilaway:
+  # This hasn't been released yet, so pin it to a specific version for reproducibility
+  version: v0.0.0-20250722134535-afb472521551
 
-# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf
-protoc_gen_go: v1.36.9
+oapi_codegen:
+  version: v2.4.1 # renovate: datasource=github-releases depName=oapi-codegen packageName=github.com/oapi-codegen/oapi-codegen
 
-# renovate: datasource=go depName=protoc-gen-go-grpc packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
-protoc_gen_go_grpc: v1.5.1
+protoc_gen_go:
+  version: v1.36.9 # renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf
 
-# renovate: datasource=github-tags depName=semversort packageName=whereswaldon/semversort
-semversort: v0.0.6
+protoc_gen_go_grpc:
+  version: v1.5.1 # renovate: datasource=go depName=protoc-gen-go-grpc packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-# renovate: datasource=github-releases depName=shellcheck packageName=koalaman/shellcheck
-shellcheck: v0.11.0
+semversort:
+  version: v0.0.6 # renovate: datasource=github-tags depName=semversort packageName=whereswaldon/semversort
 
-# renovate: datasource=github-releases depName=sqlc packageName=sqlc-dev/sqlc
-sqlc: v1.30.0
+shellcheck:
+  custom_build: true
+  version: v0.11.0 # renovate: datasource=github-releases depName=shellcheck packageName=koalaman/shellcheck
 
-# renovate: datasource=github-releases depName=skopeo packageName=containers/skopeo
-skopeo: v1.20.0
+sqlc:
+  version: v1.30.0 # renovate: datasource=github-releases depName=sqlc packageName=sqlc-dev/sqlc
 
-# renovate: datasource=github-releases depName=wire packageName=google/wire
-wire: v0.7.0
+skopeo:
+  custom_build: true
+  version: v1.20.0 # renovate: datasource=github-releases depName=skopeo packageName=containers/skopeo
 
-# renovate: datasource=github-releases depName=spectral packageName=stoplightio/spectral
-spectral: v6.15.0
+wire:
+  version: v0.7.0 # renovate: datasource=github-releases depName=wire packageName=google/wire
 
-# renovate: datasource=github-tags depName=xk6 packageName=grafana/xk6
-xk6: v1.1.4
+spectral:
+  version: v6.15.0 # renovate: datasource=github-releases depName=spectral packageName=stoplightio/spectral
 
-# renovate: datasource=github-tags depName=yq packageName=mikefarah/yq
-yq: v4.47.2
+xk6:
+  version: v1.1.4 # renovate: datasource=github-tags depName=xk6 packageName=grafana/xk6
+
+yq:
+  version: v4.47.2 # renovate: datasource=github-tags depName=yq packageName=mikefarah/yq


### PR DESCRIPTION
Rework versions.yaml so that it contains more information about the individual packages. This makes the Dockerfile.tmpl file cleaner. Update the renovate configuration to match, and clean it up in the process, too.