### PR TITLE
fix: Move renovate back to 39.23.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,8 +65,8 @@
     {
       "customType": "regex",
       "description": "update docker versions found in versions.yaml",
-      "managerFilePatterns": [
-        "/^versions\\.yaml$/"
+      "fileMatch": [
+        "^versions\\.yaml$"
       ],
       "datasourceTemplate": "docker",
       "autoReplaceStringTemplate": "version: {{newValue}} # {{newDigest}}{{{renovateStr}}}",
@@ -77,8 +77,8 @@
     {
       "customType": "regex",
       "description": "update versions found in versions.yaml",
-      "managerFilePatterns": [
-        "/^versions\\.yaml$/"
+      "fileMatch": [
+        "^versions\\.yaml$"
       ],
       "autoReplaceStringTemplate": "version: {{newValue}}{{{renovateStr}}}",
       "matchStrings": [

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -61,8 +61,8 @@ packageRules:
 customManagers:
   - customType: regex
     description: update docker versions found in versions.yaml
-    managerFilePatterns:
-      - /^versions\.yaml$/
+    fileMatch:
+      - ^versions\.yaml$
     datasourceTemplate: docker
     autoReplaceStringTemplate: |-
       version: {{newValue}} # {{newDigest}}{{{renovateStr}}}
@@ -72,8 +72,8 @@ customManagers:
 
   - customType: regex
     description: update versions found in versions.yaml
-    managerFilePatterns:
-      - /^versions\.yaml$/
+    fileMatch:
+      - ^versions\.yaml$
     autoReplaceStringTemplate: |-
       version: {{newValue}}{{{renovateStr}}}
     matchStrings:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@a889a8abcb11ef7feaafaf5e483ea01d4bf7774e # v43.0.5
         with:
-          renovate-version: 41.97.9
+          renovate-version: 39.23.0
           configurationFile: .github/renovate-app.json
           token: '${{ steps.app-token.outputs.token }}'
           docker-cmd-file: .github/renovate

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -56,3 +56,5 @@ jobs:
           persist-credentials: false
       - name: Self-hosted renovate
         uses: grafana/sm-renovate/actions/renovate-validate@main
+        with:
+          renovate-version: 39.23.0


### PR DESCRIPTION
cd61ee04b4cd1d378e1ecad45bace6da8a951259 updated the renovate version from 39.23.0 to 41.97.0. Move back to the previous value to see if this gets rid of a strange behavior where it's updating (mixing up) the depName to something non-sensical.