### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 ## [Unreleased]
 
 
+<a name="v1.21.0"></a>
+## [v1.21.0] - 2025-09-26
+### Bug Fixes
+- Update renovate version
+- Change renovate regular expressions
+- Move renovate back to 39.23.0
+- rework versions file
+- Use a sane configuration format for renovate
+
+
 <a name="v1.20.0"></a>
-## [v1.20.0] - 2025-09-18
+## [v1.20.0] - 2025-09-19
 
 <a name="v1.19.0"></a>
 ## [v1.19.0] - 2025-09-10
@@ -384,7 +394,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2023-11-24
 
-[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.20.0...HEAD
+[Unreleased]: https://github.com/grafana/grafana-build-tools/compare/v1.21.0...HEAD
+[v1.21.0]: https://github.com/grafana/grafana-build-tools/compare/v1.20.0...v1.21.0
 [v1.20.0]: https://github.com/grafana/grafana-build-tools/compare/v1.19.0...v1.20.0
 [v1.19.0]: https://github.com/grafana/grafana-build-tools/compare/v1.18.1...v1.19.0
 [v1.18.1]: https://github.com/grafana/grafana-build-tools/compare/v1.18.0...v1.18.1


### PR DESCRIPTION
* fix: Use a sane configuration format for renovate
* fix: rework versions file
* fix: Move renovate back to 39.23.0
* fix: Change renovate regular expressions
* fix: Update renovate version
* chore: Update go:1.25.1 Docker digest to 8305f5f (#427)
* chore: Update dependency lefthook to v1.13.4 (#428)
* chore: Update dependency golangci-lint to v2.5.0 (#430)
* chore: Update dependency xk6 to v1.1.5 (#429)
* chore: Update dependency k6 to v1.3.0 (#431)