### PR TITLE
chore(deps): Update dependency xk6 to v1.4.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -111,7 +111,7 @@ spectral:
   version: v6.15.0 # renovate: datasource=github-releases depName=spectral packageName=stoplightio/spectral
 
 xk6:
-  version: v1.3.7 # renovate: datasource=github-tags depName=xk6 packageName=grafana/xk6
+  version: v1.4.0 # renovate: datasource=github-tags depName=xk6 packageName=grafana/xk6
 
 yq:
   version: v4.53.2 # renovate: datasource=github-tags depName=yq packageName=mikefarah/yq


### PR DESCRIPTION
https://github.com/grafana/xk6/releases/tag/v1.4.0 adds support for k6 v2.