### PR TITLE
fix: Reenable Renovate

### DIFF
--- a/.github/renovate
+++ b/.github/renovate
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-renovate --enabled --force-cli

--- a/.github/renovate-app.json
+++ b/.github/renovate-app.json
@@ -1,7 +1,0 @@
-{
-  "customEnvVariables": {
-    "GOPRIVATE": "github.com/grafana",
-    "GONOSUMDB": "github.com/grafana",
-    "GONOPROXY": "github.com/grafana"
-  }
-}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,8 @@
     "config:best-practices",
     ":semanticCommitsDisabled"
   ],
-  "enabled": false,
-  "dependencyDashboard": false,
+  "enabled": true,
+  "dependencyDashboard": true,
   "branchPrefix": "grafanarenovatebot/",
   "commitMessagePrefix": "chore:",
   "platformCommit": "enabled",

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -4,10 +4,8 @@ extends:
   - config:best-practices
   - :semanticCommitsDisabled
 
-# This repo is public, so prevent the Mend Renovate app from trying to create
-# PRs here by setting enabled to false.
-enabled: false
-dependencyDashboard: false
+enabled: true
+dependencyDashboard: true
 
 branchPrefix: grafanarenovatebot/
 commitMessagePrefix: 'chore:'


### PR DESCRIPTION
At some point in the past, Renovate Mend app was enabled at the org level, and this caused duplicate PRs to be created, so I had to deploy a hack to disable the app but keep the self-hosted renovate workflow working. In 7db727cc0dfebcac4504bf93234c5b4c147657c7 the local workflow was removed in favor of the global one, but I forgot about the hack and the global renovate is seeing `enable: false` and not doing anything.

Remove the hack and reenable renovate.