### PR TITLE
fix(workflows): add id-token: write to release-please job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
create-github-app-token requires id-token: write to mint the OIDC assertion exchanged with GATB.