### PR TITLE
fix: Pin create-github-app-token to v0.3.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: sm-release-app
 


### PR DESCRIPTION
The create-github-app-token action was pinned to the v0.2.2 SHA, which is on the org's actions denylist. This caused every Release Please workflow run to fail with startup_failure since 2026-08-19, because GitHub rejects the job before scheduling it.

Move the pin to v0.3.1, the latest release, which is not on the denylist.